### PR TITLE
Fix jetton forward amount

### DIFF
--- a/src/api/blockchains/ton/constants.ts
+++ b/src/api/blockchains/ton/constants.ts
@@ -1,5 +1,5 @@
 export const TOKEN_TRANSFER_TON_AMOUNT = '0.05';
-export const TOKEN_TRANSFER_TON_FORWARD_AMOUNT = '0';
+export const TOKEN_TRANSFER_TON_FORWARD_AMOUNT = '0.000000001';
 
 export enum JettonOpCode {
   transfer = 0xf8a7ea5,


### PR DESCRIPTION
For all token transfers, forward amount was zero, breaking the basic functionality of jetton standard to notify the receiver about the new transfer. Increasing forward amount to 1 nanoTON fixes the ssue.