### PR TITLE
Fix sending of duplicate transactions

### DIFF
--- a/src/components/transfer/TransferPassword.tsx
+++ b/src/components/transfer/TransferPassword.tsx
@@ -1,10 +1,12 @@
-import React, { memo, type TeactNode } from '../../lib/teact/teact';
+import React, { memo, type TeactNode, useRef } from '../../lib/teact/teact';
 import { getActions } from '../../global';
 
 import { IS_CAPACITOR } from '../../config';
 
+import useEffectOnce from '../../hooks/useEffectOnce';
 import useHistoryBack from '../../hooks/useHistoryBack';
 import useLang from '../../hooks/useLang';
+import useLastCallback from '../../hooks/useLastCallback';
 
 import ModalHeader from '../ui/ModalHeader';
 import PasswordForm from '../ui/PasswordForm';
@@ -28,6 +30,19 @@ function TransferPassword({
   } = getActions();
 
   const lang = useLang();
+  const shouldSubmit = useRef(true);
+  const onSubmitWrapper = useLastCallback((password: string) => {
+    if (shouldSubmit.current) {
+      shouldSubmit.current = false;
+
+      onSubmit(password);
+    }
+  });
+
+  useEffectOnce(() => {
+    // Reset when the component is mounted, to allow next transfers through
+    shouldSubmit.current = true;
+  });
 
   useHistoryBack({
     isActive,
@@ -47,7 +62,7 @@ function TransferPassword({
         error={error}
         submitLabel={lang('Send')}
         cancelLabel={lang('Back')}
-        onSubmit={onSubmit}
+        onSubmit={onSubmitWrapper}
         onCancel={onCancel}
         onUpdate={clearTransferError}
       >


### PR DESCRIPTION
Hello. I've found and fixed a bug with keyboard navigation that allowed to send the same transaction many times.  
I was sending a transaction and once I was on the "Coins have been sent!" modal, I pressed enter expecting it to close, but it didn't (addressed in #137). After that I saw that my transaction was successfully sent out twice!  
I think this is a critical bug that could lead to loss of funds.

## Reproducing
Using the Firefox extension, version `3.0.10`.  
Steps to reproduce:
- Open MyTonWallet main screen
- Click send
- Set any address and any amount of any token
- Click "Send" then "Confirm". Then enter password and click "Send"
- Once on the "Coins have been sent!" modal, press enter, the transaction will be repeated, as many times as enter is pressed

## Cause of the bug
The root component of this issue is `TransferModal`'s `TransferPassword` that's wrapped in a `Transition`.  
`TransferPassword`'s `PasswordForm` captures the keyboard to submit the password on a press of enter, it's supposed to let go of the keyboard once it's not rendered.  
But it's always rendered, since `TransferPassword` and other components are wrapped in a `Transition`. And because `Transition` always renders the previous component in a transition - `TransferPassword` is rendered when it's not expected to, so the keyboard is not released and transactions can be sent many times.

## Fix
To fix this I added a variable to `TransferPassword` that tracks if the password has already been submitted and ignores any further attempts, and resets it when the component is mounted another time, when it's already a different transaction.

Do you have bug bounty for these types of bugs? I asked your telegram support but they didn't answer this question.
