### PR TITLE
Update macOS Requirements in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To build on **Windows**, you will also need:
 ### Prepare macOS
 `node-gyp` tries to build `node-canvas`, so we pre-install [all necessary dependencies](https://github.com/Automattic/node-canvas/wiki/Installation:-Mac-OS-X#homebrew) in advance.
 ```sh
-brew install pkg-config cairo pango libpng jpeg giflib librsvg
+brew install pkg-config cairo pango libpng jpeg giflib librsvg python-setuptools
 ```
 
 ### NPM Local Setup


### PR DESCRIPTION
When building canvas with `node-gyp`, you might encounter the error `ModuleNotFoundError: No module named 'distutils'`. 

Running `brew install python-setuptools` can help address this issue. 

Sending this Pull Request to include this dependency in the README.

Thank you for all your work! 