### PR TITLE
Support for Custom User-Agent in MyTonWallet

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -1,5 +1,6 @@
 import type { CapacitorConfig } from '@capacitor/cli';
 import type { KeyboardResize } from '@capacitor/keyboard';
+import pkg from './package.json';
 
 const { APP_ENV = 'production' } = process.env;
 
@@ -43,6 +44,7 @@ const config: CapacitorConfig = {
     path: 'mobile/android',
     includePlugins: COMMON_PLUGINS,
     webContentsDebuggingEnabled: APP_ENV !== 'production',
+    overrideUserAgent: `MyTonWallet/${pkg.version} (Android)`,
   },
   ios: {
     path: 'mobile/ios',
@@ -54,6 +56,7 @@ const config: CapacitorConfig = {
     // expected the main WebView to be focused instead of the Sheet. With the parameter, both the contexts are out of
     // focus at the app start, and after ~60ms the main WebView gets the focus, which is ok for the app.
     initialFocus: false,
+    overrideUserAgent: `MyTonWallet/${pkg.version} (iOS)`,
   },
   plugins: {
     SplashScreen: {

--- a/src/components/ui/InAppBrowser.tsx
+++ b/src/components/ui/InAppBrowser.tsx
@@ -89,7 +89,7 @@ function InAppBrowser({
       `sharecaption=${lang('Share')}`,
       `theme=${theme}`,
       `animated=${animationLevel ?? ANIMATION_LEVEL_DEFAULT > 0 ? 'yes' : 'no'}`,
-      `User-Agent=MyTonWallet/${pkg.version} (${IS_IOS ? 'iOS' : 'Android'})`
+      `userAgent=MyTonWallet/${pkg.version} (${IS_IOS ? 'iOS' : 'Android'})`
     ]).join(',')}`;
     inAppBrowser = cordova.InAppBrowser.open(url,
       '_blank',

--- a/src/components/ui/InAppBrowser.tsx
+++ b/src/components/ui/InAppBrowser.tsx
@@ -19,6 +19,8 @@ import { useDappBridge } from '../explore/hooks/useDappBridge';
 
 import { getIsAnyNativeBottomSheetModalOpen } from './Modal';
 
+import pkg from '../../package.json';
+
 interface StateProps {
   title?: string;
   subtitle?: string;
@@ -87,6 +89,7 @@ function InAppBrowser({
       `sharecaption=${lang('Share')}`,
       `theme=${theme}`,
       `animated=${animationLevel ?? ANIMATION_LEVEL_DEFAULT > 0 ? 'yes' : 'no'}`,
+      `User-Agent=MyTonWallet/${pkg.version} (${IS_IOS ? 'iOS' : 'Android'})`
     ]).join(',')}`;
     inAppBrowser = cordova.InAppBrowser.open(url,
       '_blank',


### PR DESCRIPTION
Hello Team,

Prepared an example to add support for a custom User Agent in MyTonWallet. This allows apps opened via the In-App Browser to detect that the source is MyTonWallet, enabling customized themes, experiences, login pages, etc.

The `capacitor.config.ts` changes might not be needed, those affect the main app wrapper, added just in case. 
However, the modifications in `InAppBrowser.ts` should do the trick.

After building, test with e.g: [whatmyuseragent.com](https://whatmyuseragent.com/) to confirm the changes apply correctly.

Hope it helps, and we can see a similar implementation in MyTonWallet in the near future.

Thank you for all your work