### PR TITLE
Update InAppBrowser with Custom UA

### DIFF
--- a/src/components/ui/InAppBrowser.tsx
+++ b/src/components/ui/InAppBrowser.tsx
@@ -19,6 +19,8 @@ import { useDappBridge } from '../explore/hooks/useDappBridge';
 
 import { getIsAnyNativeBottomSheetModalOpen } from './Modal';
 
+import pkg from '../../../package.json';
+
 interface StateProps {
   title?: string;
   subtitle?: string;
@@ -87,6 +89,7 @@ function InAppBrowser({
       `sharecaption=${lang('Share')}`,
       `theme=${theme}`,
       `animated=${animationLevel ?? ANIMATION_LEVEL_DEFAULT > 0 ? 'yes' : 'no'}`,
+      `appendUserAgent=MyTonWallet/${pkg.version} (${theme})`
     ]).join(',')}`;
     inAppBrowser = cordova.InAppBrowser.open(url,
       '_blank',


### PR DESCRIPTION
Hello Team,

I’ve prepared a PR to add support for a custom User Agent in MyTonWallet. This allows apps opened via the In-App Browser to detect that the source is MyTonWallet, enabling customized themes, experiences, login pages, etc.

The UA is appended, not replacing the original User Agent but adding an identifier from the app in the format: `MyTonWallet/version (theme)`

Default UA:
`Mozilla/5.0 (iPhone; CPU iPhone OS 18_5_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/138.0.7204.56 Mobile/15E148 Safari/604.1`

Results in:
`Mozilla/5.0 (iPhone; CPU iPhone OS 18_5_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/138.0.7204.56 Mobile/15E148 Safari/604.1 MyTonWallet/3.8.0 (dark)`

This is only applies to Cordova InAppBrowser, which is only used on iOS and Android platforms.

| Previous PR: https://github.com/mytonwalletorg/mytonwallet/pull/258 |