### PR TITLE
🐛 Fixed issue: removed re-open of the keyboard after pincode set

### DIFF
--- a/mobile/android/air/SubModules/UIPasscode/src/main/java/org/mytonwallet/app_air/uipasscode/viewControllers/setPasscode/SetPasscodeVC.kt
+++ b/mobile/android/air/SubModules/UIPasscode/src/main/java/org/mytonwallet/app_air/uipasscode/viewControllers/setPasscode/SetPasscodeVC.kt
@@ -165,10 +165,13 @@ class SetPasscodeVC(
             insetsUpdatedBefore &&
             (window?.imeInsets?.bottom ?: 0) == 0
         ) {
-            if (!confirmedPasscode && wasShowingKeyboard)
-                pop()
-            else
-                passcodeInputView.requestFocus()
+            if (!confirmedPasscode){
+                if (wasShowingKeyboard)
+                    pop()
+                else
+                    passcodeInputView.requestFocus()
+            }
+
         }
         wasShowingKeyboard = isKeyboardOpen
         insetsUpdatedBefore = true


### PR DESCRIPTION
Fixed issue: removed re-open of the keyboard after pincode set if there is no biometic available for the device.

Why it solves:
After passcode is confirmed and user don't have biometrics available, the keyboard was closed and this part was triggered. 

Since passcode was confirmed and we are still on this page - passcodeInputView.requestFocus() was triggered.

Now this both pop() and passcodeInputView.requestFocus() only triggered only before passcodeConfirmed