### PR TITLE
feat: Add “View Sample” fallback for multi-send CSV on /droppage (Web…

### DIFF
--- a/src/multisend/components/DropPage.module.scss
+++ b/src/multisend/components/DropPage.module.scss
@@ -171,8 +171,140 @@
   background-color: var(--color-accent);
 }
 
+.csvSampleOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+}
+
+.csvSampleModal {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 600px;
+  max-height: 80vh;
+  padding: 1.5rem;
+  border-radius: var(--border-radius-default);
+  background-color: var(--color-background-first);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.csvSampleHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--color-separator);
+}
+
+.csvSampleTitle {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--color-black);
+}
+
+.csvSampleHeaderButtons {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.csvSampleCopyIcon {
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background-color: transparent;
+  color: var(--color-gray-2);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s, color 0.2s;
+
+  &:hover {
+    background-color: var(--color-gray-3);
+    color: var(--color-accent);
+  }
+
+  i {
+    font-size: 1rem;
+  }
+}
+
+.csvSampleClose {
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background-color: transparent;
+  font-size: 1.5rem;
+  line-height: 1;
+  color: var(--color-gray-2);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s, color 0.2s;
+
+  &:hover {
+    background-color: var(--color-gray-3);
+    color: var(--color-black);
+  }
+}
+
+.csvSampleContent {
+  flex: 1;
+  overflow-y: scroll;
+  overflow-x: auto;
+  min-height: 0;
+}
+
+.csvSampleText {
+  margin: 0;
+  padding: 1rem;
+  border-radius: var(--border-radius-default);
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  color: var(--color-black);
+  background-color: var(--color-background-second);
+  white-space: pre;
+  overflow-x: auto;
+  width: 100%;
+  min-width: max-content;
+}
+
+.csvSampleCopyButton {
+  background-color: var(--color-background-first);
+}
+
 @media (max-width: 480px) {
   .importPanel {
     padding: 1rem;
+  }
+
+  .csvSampleModal {
+    padding: 1rem;
+    max-height: 90vh;
+  }
+
+  .csvSampleText {
+    font-size: 0.75rem;
   }
 }


### PR DESCRIPTION
# Pull Request: Add “View Sample” fallback for multi-send CSV on /droppage (WebView fix)

## Summary
This PR adds a **“View Sample”** fallback button to `/droppage` so users inside the **MyTonWallet in-app WebView** (Android/iOS) can access the multi-send sample CSV.  
Downloading via `Blob + a.click()` is blocked in WebViews, so the sample file could not be downloaded previously.

---

## What’s changed
- Added **“View Sample”** button on **/droppage**  
- Opens a modal (or inline view) showing the full multi-send sample CSV  
- Allows users to **copy** the CSV manually  
- Normal download behavior kept for browsers where it works  
- Improves UX for users accessing multisend through the MyTonWallet old design → Multi Send flow

---

## Why
Users opening multisend from inside the MyTonWallet app (old design → long press Send → Multi Send) were unable to download the required sample CSV because:
- WebViews block `blob:` URLs  
- WebViews block programmatic downloads (`a.click()`)

This PR ensures they can still access the CSV content.

<img width="200" height="420" alt="Screenshot 2025-11-20 at 04 16 56" src="https://github.com/user-attachments/assets/745eae46-d687-444f-bcca-77f9376e8d97" />

<img width="200" height="420" alt="Screenshot 2025-11-20 at 04 16 50" src="https://github.com/user-attachments/assets/e24d6f18-c422-4bf0-a219-1e008cb1c78b" />

---

## Related Issue
Fixes: #307 

