### PR TITLE
[Electron] Build: Pin Windows nsis target to x64 arch

### DIFF
--- a/src/electron/config.yml
+++ b/src/electron/config.yml
@@ -34,7 +34,10 @@ publish:
   repo: "mytonwallet"
   releaseType: "draft"
 win:
-  target: "nsis"
+  target:
+    - target: "nsis"
+      arch:
+        - x64
   icon: "public/icon-electron-windows.ico"
 nsis:
   oneClick: false


### PR DESCRIPTION
The v26.6.1 squash collapsed `win.target` to the string shorthand `"nsis"`, which builds Windows for the runner host arch. `electron-release` runs on `macos-15` (Apple Silicon), so the dispatch produced `MyTonWallet-arm64.exe` and the x64 artifact upload failed. This pins the target to x64 explicitly so the x64-only Windows build actually comes out x64. Mirrors mytonwallet-dev #9807.